### PR TITLE
Parallelizing tests

### DIFF
--- a/distro_test.go
+++ b/distro_test.go
@@ -155,6 +155,7 @@ configuration: error in GetConfiguration: failed to convert %q to UTF16
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			d := *tc.distro
 			got := d.String()
 			require.Equal(t, tc.wants, got)
@@ -326,6 +327,7 @@ func TestGetConfiguration(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			d := wsl.Distro{Name: tc.distroName}
 			c, err := d.GetConfiguration()
 

--- a/distro_test.go
+++ b/distro_test.go
@@ -114,6 +114,9 @@ func TestDistroSetAsDefault(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestDistroString(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
@@ -312,6 +315,10 @@ func TestConfigurationSetters(t *testing.T) {
 		})
 	}
 }
+
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestGetConfiguration(t *testing.T) {
 	d := newTestDistro(t, jammyRootFs)
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestExitErrorIs(t *testing.T) {
+	t.Parallel()
 	reference := wsl.ExitError{Code: 35}
 	exit := wsl.ExitError{Code: 5}
 	err := errors.New("")
@@ -96,6 +97,7 @@ func TestCommandRun(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			d := realDistro
 			if tc.fakeDistro {
 				d = fakeDistro
@@ -249,6 +251,7 @@ func TestCommandStartWait(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			var cancel context.CancelFunc
 			if tc.cancelOn != Never {
@@ -355,6 +358,7 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >&2")
 
 			var buff bytes.Buffer
@@ -404,6 +408,7 @@ func TestCommandOutput(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			cmd := tc.distro.Command(ctx, tc.cmd)
@@ -464,6 +469,7 @@ func TestCommandCombinedOutput(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
@@ -526,6 +532,7 @@ print("Your text was", v)
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			if tc.text == "" {
 				tc.text = "Hello, wsl!"
 			}

--- a/exec_test.go
+++ b/exec_test.go
@@ -48,6 +48,9 @@ func TestExitErrorAsString(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandRun(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
@@ -150,6 +153,9 @@ func TestCommandRun(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandStartWait(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
@@ -339,6 +345,9 @@ func TestCommandStartWait(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandOutPipes(t *testing.T) {
 	d := newTestDistro(t, jammyRootFs)
 
@@ -377,6 +386,9 @@ func TestCommandOutPipes(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandOutput(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
@@ -437,6 +449,9 @@ func TestCommandOutput(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandCombinedOutput(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}
@@ -500,6 +515,9 @@ func TestCommandCombinedOutput(t *testing.T) {
 	}
 }
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestCommandStdin(t *testing.T) {
 	d := newTestDistro(t, jammyRootFs)
 

--- a/shell_test.go
+++ b/shell_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint: tparallel
+// Top-level test cannot be parallel because "newTestDistro" may shutdown WSL, interfering with all
+// other tests.
 func TestShell(t *testing.T) {
 	realDistro := newTestDistro(t, jammyRootFs)
 	fakeDistro := wsl.Distro{Name: uniqueDistroName(t)}

--- a/shell_test.go
+++ b/shell_test.go
@@ -50,6 +50,7 @@ func TestShell(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			d := *tc.distro
 
 			// Because Shell is an interactive command, it needs to be quit from


### PR DESCRIPTION
Up until now we knew something spooky was going on with tests that cause them to fail when run in parallel.

We now know the problem: The same executable cannot make two calls to `WslRegisterDistribution`. This means that all tests of functionality outside of this are free to be parallelized.

These parallelized tests are those that neither:
- shutdown nor have the potential to shutdown WSL, nor
- interfere with one another, nor
- modify any observable global state