### PR TITLE
Simplify CI by avoiding use of RDP

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Set up WSL
+        uses: Ubuntu/WSL/.github/actions/wsl-install@main
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -18,15 +18,14 @@ jobs:
     name: Set up Azure VM
     runs-on: ubuntu-latest
     steps:
-      - name: Start Azure VM
-        uses: ubuntu/WSL/.github/actions/vm-setup/@main
+      - name: Azure login
+        uses: azure/login@v1
         with:
-          az_name: ${{ env.az_name }}
-          az_resource_group: ${{ env.az_resource_group }}
-          az_creds: ${{ secrets.AZURE_VM_CREDS }}
-          az_vm_hostname: ${{ secrets.AZURE_VM_AUTHORITY }}
-          az_vm_username: ${{ secrets.AZURE_VM_UN }}
-          az_vm_password: ${{ secrets.AZURE_VM_UP }}
+          creds: ${{ secrets.AZURE_VM_CREDS }}
+      - name: Start the Runner
+        shell: bash
+        run: |
+          az vm start --name ${{ env.az_name }} --resource-group ${{ env.az_resource_group }}
       - name: Cancel workflow on failure
         # The qa step can get stuck forever waiting for a VM that will never wake up.
         # This step ensures that the workflow is cancelled if the vm setup fails.
@@ -78,9 +77,10 @@ jobs:
     # won't be started until then. Don't make the dependency explicit: it
     # needs to run concurrently with vm-setup.
     steps:
-      - name: Stop Azure VM
-        uses: ubuntu/WSL/.github/actions/vm-stop/@main
+      - uses: azure/login@v1
         with:
-          az_name: ${{ env.az_name }}
-          az_resource_group: ${{ env.az_resource_group }}
-          az_creds: ${{ secrets.AZURE_VM_CREDS }}
+          creds: ${{ secrets.AZURE_VM_CREDS }}
+      - name: Deallocate the Runner
+        shell: bash
+        run: |
+          az vm deallocate --name ${{ env.az_name }} --resource-group ${{ env.az_resource_group }}

--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -26,30 +26,11 @@ jobs:
         shell: bash
         run: |
           az vm start --name ${{ env.az_name }} --resource-group ${{ env.az_resource_group }}
-      - name: Cancel workflow on failure
-        # The qa step can get stuck forever waiting for a VM that will never wake up.
-        # This step ensures that the workflow is cancelled if the vm setup fails.
-        #
-        # API call docs:
-        # See https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#cancel-a-workflow-run
-        #
-        # Relevant discussion:
-        # https://github.com/orgs/community/discussions/38361
-        if: failure()
-        run: |
-          curl \
-            -X POST \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel"
 
   qa:
     name: Run QA checks on the Azure VM
     runs-on: self-hosted
-    # This step has an implicit dependency on vm-setup, because the runner
-    # won't be started until then. Don't make the dependency explicit: it
-    # needs to run concurrently with vm-setup.
+    needs: vm-setup
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -71,13 +52,11 @@ jobs:
   stop-vm:
     name: Clean up the Azure VM
     runs-on: ubuntu-latest
-    needs: qa
+    needs: [vm-setup, qa]
     if: always()
-    # This step has an implicit dependency on vm-setup, because the runner
-    # won't be started until then. Don't make the dependency explicit: it
-    # needs to run concurrently with vm-setup.
     steps:
-      - uses: azure/login@v1
+      - name: Azure login
+        uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_VM_CREDS }}
       - name: Deallocate the Runner


### PR DESCRIPTION
RDP was used to create a user session. We can do that with an automatic logon instead, and adding the GitHub runner as a startup program.

UDENG-297