### PR TITLE
Fix redirecting WslLaunch's output to a file

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -3,6 +3,9 @@ package gowsl
 // This file contains windows-only API definitions and imports
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"syscall"
 	"unsafe"
 
@@ -33,4 +36,46 @@ type char = byte     // Windows' CHAR (which is the same as C's char)
 
 func coTaskMemFree(p unsafe.Pointer) {
 	windows.CoTaskMemFree(p)
+}
+
+// startProcess replaces os.StartProcess with WSL commands.
+func (c Cmd) startProcess() (process *os.Process, err error) {
+	distroUTF16, err := syscall.UTF16PtrFromString(c.distro.Name())
+	if err != nil {
+		return nil, errors.New("failed to convert distro name to UTF16")
+	}
+
+	commandUTF16, err := syscall.UTF16PtrFromString(c.command)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert command %q to UTF16", c.command)
+	}
+
+	var useCwd wBOOL
+	if c.UseCWD {
+		useCwd = 1
+	}
+
+	var handle windows.Handle
+	r1, _, _ := wslLaunch.Call(
+		uintptr(unsafe.Pointer(distroUTF16)),
+		uintptr(unsafe.Pointer(commandUTF16)),
+		uintptr(useCwd),
+		c.stdinR.Fd(),
+		c.stdoutW.Fd(),
+		c.stderrW.Fd(),
+		uintptr(unsafe.Pointer(&handle)))
+
+	if r1 != 0 {
+		return nil, fmt.Errorf("failed syscall to WslLaunch")
+	}
+	if handle == windows.Handle(0) {
+		return nil, fmt.Errorf("syscall to WslLaunch returned a null handle")
+	}
+
+	pid, err := windows.GetProcessId(handle)
+	if err != nil {
+		return nil, errors.New("failed to find launched process")
+	}
+
+	return os.FindProcess(int(pid))
 }

--- a/examples/demo.go
+++ b/examples/demo.go
@@ -37,8 +37,7 @@ func main() {
 	// programs such as bash, python, etc. it'll will start an interactive session
 	// that the user can interact with. This is presumably what wsl.exe uses.
 	// It is a blocking call.
-	err := distro.Shell(wsl.WithCommand("sh -c 'powershell.exe'"))
-	if err != nil {
+	if err := distro.Shell(wsl.WithCommand("sh -c 'powershell.exe'")); err != nil {
 		fmt.Printf("Interactive session unsuccesful: %v\n", err)
 	} else {
 		fmt.Println("Interactive session succesful")
@@ -53,9 +52,9 @@ func main() {
 	distro.Command(context.Background(), `echo "Hello, world from WSL!" > "goodmorning.txt"`).Run()
 
 	// Waiting for command 1
-	err = cmd1.Wait()
+
 	target := &exec.ExitError{}
-	switch {
+	switch err := cmd1.Wait(); {
 	case err == nil:
 		fmt.Printf("Succesful async command!\n")
 	case errors.As(err, &target):
@@ -71,8 +70,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	err = distro.Command(ctx, "sleep 5 && echo 'Woke up!'").Run()
-	if err != nil {
+	if err := distro.Command(ctx, "sleep 5 && echo 'Woke up!'").Run(); err != nil {
 		fmt.Printf("Process with timeout failed: %v\n", err)
 	} else {
 		fmt.Println("Process with timeout succeeded!")

--- a/exec.go
+++ b/exec.go
@@ -347,7 +347,16 @@ func (c *Cmd) readerDescriptor(r io.Reader) (f *os.File, err error) {
 	}
 
 	if f, ok := r.(*os.File); ok {
-		return f, nil
+		ft, err := fileType(f)
+		if err == nil && ft == fileTypePipe {
+			// It's a pipe: no need to create our own pipe.
+			return f, nil
+		}
+		// General case: it is not a pipe (or we don't know for sure).
+		// As such, we create a pipe to connect WslLaunch to the file.
+		// This would seem unnecessary, but for some reason WslLaunch
+		// fails silently if you try to redirect its streams
+		// to something other than a pipe.
 	}
 
 	pr, pw, err := os.Pipe()
@@ -381,7 +390,16 @@ func (c *Cmd) writerDescriptor(w io.Writer) (f *os.File, err error) {
 	}
 
 	if f, ok := w.(*os.File); ok {
-		return f, nil
+		ft, err := fileType(f)
+		if err == nil && ft == fileTypePipe {
+			// It's a pipe: no need to create our own pipe.
+			return f, nil
+		}
+		// General case: it is not a pipe (or we don't know for sure).
+		// As such, we create a pipe to connect WslLaunch to the file.
+		// This would seem unnecessary, but for some reason WslLaunch
+		// fails silently if you try to redirect its streams
+		// to something other than a pipe.
 	}
 
 	pr, pw, err := os.Pipe()

--- a/exec_test.go
+++ b/exec_test.go
@@ -350,15 +350,13 @@ func TestCommandOutPipes(t *testing.T) {
 		"stdout to buffer, stderr to file": {stdout: buffer, stderr: file, wantInFile: "Hello stderr\n", wantInBuffer: "Hello stdout\n"},
 	}
 
-	tmpDir := t.TempDir()
-
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >&2")
 
 			bufferRW := &bytes.Buffer{}
-			fileRW, err := os.CreateTemp(tmpDir, "log_*.txt")
+			fileRW, err := os.CreateTemp(t.TempDir(), "log_*.txt")
 			require.NoError(t, err, "could not create file")
 			defer fileRW.Close()
 
@@ -553,7 +551,6 @@ v = input("Write your text here: ")
 sleep(1)					        # Ensures we get the prompts in separate reads
 print("Your text was", v)
 '`
-	tmpDir := t.TempDir()
 
 	for name, tc := range testCases {
 		tc := tc
@@ -583,7 +580,7 @@ print("Your text was", v)
 				stdin = stdinbuff
 			case readFromFile:
 				// Writing input text to file
-				file, err := os.CreateTemp(tmpDir, "log_*.txt")
+				file, err := os.CreateTemp(t.TempDir(), "log_*.txt")
 				defer file.Close()
 				require.NoError(t, err, "setup: could not create file")
 				_, err = file.Write([]byte(tc.text + "\n"))

--- a/exec_test.go
+++ b/exec_test.go
@@ -328,7 +328,6 @@ func TestCommandOutPipes(t *testing.T) {
 		stdout stream
 		stderr stream
 
-		skip         bool // Known bugs
 		wantInFile   string
 		wantInBuffer string
 	}{
@@ -340,13 +339,13 @@ func TestCommandOutPipes(t *testing.T) {
 		"stdout and stderr to a buffer": {stdout: buffer, stderr: buffer, wantInBuffer: "Hello stdout\nHello stderr\n"},
 
 		// Writing to file
-		"stdout to file":            {stdout: file, wantInFile: "Hello stdout\n", skip: true},
-		"stderr to file":            {stderr: file, wantInFile: "Hello stderr\n", skip: true},
-		"stdout and stderr to file": {stdout: file, stderr: file, wantInFile: "Hello stdout\nHello stderr\n", skip: true},
+		"stdout to file":            {stdout: file, wantInFile: "Hello stdout\n"},
+		"stderr to file":            {stderr: file, wantInFile: "Hello stderr\n"},
+		"stdout and stderr to file": {stdout: file, stderr: file, wantInFile: "Hello stdout\nHello stderr\n"},
 
 		// Mixed
-		"stdout to file, stderr to buffer": {stdout: file, stderr: buffer, wantInFile: "Hello stdout\n", wantInBuffer: "Hello stderr\n", skip: true},
-		"stdout to buffer, stderr to file": {stdout: buffer, stderr: file, wantInFile: "Hello stderr\n", wantInBuffer: "Hello stdout\n", skip: true},
+		"stdout to file, stderr to buffer": {stdout: file, stderr: buffer, wantInFile: "Hello stdout\n", wantInBuffer: "Hello stderr\n"},
+		"stdout to buffer, stderr to file": {stdout: buffer, stderr: file, wantInFile: "Hello stderr\n", wantInBuffer: "Hello stdout\n"},
 	}
 
 	tmpDir := t.TempDir()
@@ -354,10 +353,6 @@ func TestCommandOutPipes(t *testing.T) {
 	for name, tc := range testCases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			if tc.skip {
-				t.Skip("Skipping test because it is a known bug")
-			}
-
 			cmd := d.Command(context.Background(), "echo 'Hello stdout' >&1 && sleep 1 && echo 'Hello stderr' >&2")
 
 			bufferRW := &bytes.Buffer{}

--- a/exec_test.go
+++ b/exec_test.go
@@ -21,9 +21,8 @@ func TestCommandRun(t *testing.T) {
 	realDistro := newTestDistro(t, rootFs)
 	fakeDistro := wsl.NewDistro(uniqueDistroName(t))
 
-	// Poking distro to wake it up
-	err := realDistro.Command(context.Background(), "exit 0").Run()
-	require.NoError(t, err)
+	// Keeping distro awake so there are no unexpected timeouts
+	defer keepAwake(t, context.Background(), &realDistro)()
 
 	// Enum with various times in the execution
 	type when uint
@@ -121,6 +120,9 @@ func TestCommandStartWait(t *testing.T) {
 	realDistro := newTestDistro(t, rootFs)
 	fakeDistro := wsl.NewDistro(uniqueDistroName(t))
 	wrongDistro := wsl.NewDistro(uniqueDistroName(t) + "--IHaveA\x00NullChar!")
+
+	// Keeping distro awake so there are no unexpected timeouts
+	defer keepAwake(t, context.Background(), &realDistro)()
 
 	// Enum with various times in the execution
 	type when uint

--- a/exec_test.go
+++ b/exec_test.go
@@ -48,8 +48,8 @@ func TestCommandRun(t *testing.T) {
 		"command with null char error": {cmd: "echo \x00", fakeDistro: true, wantError: true},
 
 		// timeout cases
-		"success with timeout long enough":     {cmd: "exit 0", timeout: 6 * time.Second},
-		"linux error with timeout long enough": {cmd: "exit 42", timeout: 6 * time.Second, wantError: true, wantExitCode: 42},
+		"success with timeout long enough":     {cmd: "exit 0", timeout: 10 * time.Second},
+		"linux error with timeout long enough": {cmd: "exit 42", timeout: 10 * time.Second, wantError: true, wantExitCode: 42},
 		"fake distro with timeout long enough": {cmd: "exit 0", fakeDistro: true, wantError: true},
 		"timeout before Run":                   {cmd: "exit 0", timeout: 1 * time.Nanosecond, wantError: true},
 		"timeout during Run":                   {cmd: "sleep 3 && exit 0", timeout: 2 * time.Second, wantError: true},
@@ -182,10 +182,10 @@ func TestCommandStartWait(t *testing.T) {
 		"failure exit code both pipes":  {distro: &realDistro, cmd: "echo 'Hello!' && sleep 1 && echo 'Error!' 1>&2 && exit 42", stdoutPipe: true, wantStdout: "Hello!\n", stderrPipe: true, wantStderr: "Error!\n", wantErrOn: AfterWait, wantExitError: 42},
 
 		// Timeout context
-		"timeout success":          {distro: &realDistro, cmd: "exit 0", timeout: 2 * time.Second},
-		"timeout exit code":        {distro: &realDistro, cmd: "exit 42", timeout: 2 * time.Second, wantErrOn: AfterWait, wantExitError: 42},
+		"timeout success":          {distro: &realDistro, cmd: "exit 0", timeout: 10 * time.Second},
+		"timeout exit code":        {distro: &realDistro, cmd: "exit 42", timeout: 10 * time.Second, wantErrOn: AfterWait, wantExitError: 42},
 		"timeout before execution": {distro: &realDistro, cmd: "exit 0", timeout: time.Nanosecond, wantErrOn: AfterStart},
-		"timeout during execution": {distro: &realDistro, cmd: "sleep 3", timeout: 2 * time.Second, wantErrOn: AfterWait},
+		"timeout during execution": {distro: &realDistro, cmd: "sleep 5", timeout: 3 * time.Second, wantErrOn: AfterWait},
 
 		// Cancel context
 		"cancel success":          {distro: &realDistro, cmd: "exit 0", cancelOn: AfterWait},

--- a/shell_test.go
+++ b/shell_test.go
@@ -23,11 +23,11 @@ func TestShell(t *testing.T) {
 	wrongCommand := "echo 'Oh no!, There is a \x00 in my command!'"
 
 	testCases := map[string]struct {
-		withCwd       bool
-		withCommand   *string
-		distro        *wsl.Distro
-		wantError     bool
-		wantExitError uint32
+		withCwd      bool
+		withCommand  *string
+		distro       *wsl.Distro
+		wantError    bool
+		wantExitCode uint32
 	}{
 		// Test with no arguments
 		"happy path":   {distro: &realDistro},
@@ -40,7 +40,7 @@ func TestShell(t *testing.T) {
 
 		// Test withCommand
 		"success with command":              {distro: &realDistro, withCommand: &cmdExit0},
-		"failure command with exit error":   {distro: &realDistro, withCommand: &cmdExit42, wantError: true, wantExitError: 42},
+		"failure command with exit error":   {distro: &realDistro, withCommand: &cmdExit42, wantError: true, wantExitCode: 42},
 		"failure with null char in command": {distro: &realDistro, withCommand: &wrongCommand, wantError: true},
 
 		// Test that UseCWD actually changes the working directory
@@ -95,16 +95,20 @@ func TestShell(t *testing.T) {
 			close(done)
 
 			if !tc.wantError {
-				require.NoError(t, err, "Unexpected failure after Distro.Shell")
+				require.NoError(t, err, "Unexpected error after Distro.Shell")
 				return
 			}
 
 			require.Error(t, err, "Unexpected success after Distro.Shell")
-			if tc.wantExitError == 0 {
+
+			var target *wsl.ShellError
+			if tc.wantExitCode == 0 {
+				notErrorAsf(t, err, &target, "unexpected ShellError, expected any other type")
 				return
 			}
-			require.ErrorIs(t, err, wsl.ExitError{}, "Expected exit error returned from Distro.Shell")
-			require.Equal(t, tc.wantExitError, err.(*wsl.ExitError).Code, "Unexpected value for ExitCode returned from Distro.Shell") //nolint: forcetypeassert, errorlint
+
+			require.ErrorAs(t, err, &target, "unexpected error type, expected a ShellError")
+			require.Equal(t, tc.wantExitCode, target.ExitCode(), "Unexpected value for ExitCode returned from Distro.Shell")
 		})
 	}
 }

--- a/shell_test.go
+++ b/shell_test.go
@@ -3,6 +3,7 @@ package gowsl_test
 import (
 	wsl "github.com/ubuntu/gowsl"
 
+	"context"
 	"testing"
 	"time"
 
@@ -52,6 +53,11 @@ func TestShell(t *testing.T) {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			d := *tc.distro
+
+			// Keeping distro awake so there are no unexpected timeouts
+			if d == realDistro {
+				defer keepAwake(t, context.Background(), &realDistro)()
+			}
 
 			// Because Shell is an interactive command, it needs to be quit from
 			// outside. This goroutine sets a fuse before shutting down the distro.


### PR DESCRIPTION
Passing a real file descriptor to WslLaunch does not write to a file for some reason, so I have to stick an intermediate pipe in there. This pull request does two things that should have probably been two separate PR, but became too intertwined:
- Refactors Cmd so that it more closely resembles the stdlib. See commit
_Brought (*distro).Cmd closer to the standard library_ for more details.
- Adds tests that fail, proving that we do not write to file
- Adds the intermediate pipe, making the tests pass.

WSL-401