### PR TITLE
Upgrade to go 1.20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
       - name: Build
         shell: powershell
         run: go build -v ./...
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.20"
       - name: Prepare repo
         shell: powershell
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: Build
         shell: powershell
         run: go build -v ./...

--- a/.golangci-ci.yaml
+++ b/.golangci-ci.yaml
@@ -65,4 +65,4 @@ linters-settings:
   staticcheck:
     # Should be better for it to be autodetected
     # https://github.com/golangci/golangci-lint/issues/2234
-    go: "1.18"
+    go: "1.20"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We aim not to extend the aforementioned API, but rather to provide a safe, idiom
 ## Requirements
 
 - Windows Subsystem for Linux must be installed ([documentation](https://learn.microsoft.com/en-us/windows/wsl/install)) and enabled.
-- Go version must be equal to or above 1.18.
+- Go version must be equal to or above 1.20.
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/gowsl
 
-go 1.18
+go 1.20
 
 require golang.org/x/sys v0.4.0
 

--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	}
 	defer restore()
 
-	rand.Seed(time.Now().UnixNano())
 	exitVal := m.Run()
 
 	err = wsl.Shutdown()


### PR DESCRIPTION
go 1.18 is no longer supported so let's upgrade to 1.20