### PR TITLE
Implement distroState

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/ubuntu/gowsl/internal/flags"
+	"github.com/ubuntu/gowsl/internal/state"
 )
 
 // RegistryKey mocks a very small subset of behaviours of a Windows Registry key, enough
@@ -22,6 +23,7 @@ type Backend interface {
 	OpenLxssRegistry(path string) (RegistryKey, error)
 
 	// wsl.exe
+	State(distributionName string) (state.State, error)
 	Shutdown() error
 	Terminate(distroName string) error
 	SetAsDefault(distroName string) error

--- a/internal/backend/windows/wslexe_linux.go
+++ b/internal/backend/windows/wslexe_linux.go
@@ -4,6 +4,8 @@ package windows
 
 import (
 	"errors"
+
+	"github.com/ubuntu/gowsl/internal/state"
 )
 
 // Shutdown shuts down all distros
@@ -22,4 +24,10 @@ func (Backend) Terminate(distroName string) error {
 // This implementation will always fail on Linux.
 func (Backend) SetAsDefault(distroName string) error {
 	return errors.New("not implemented")
+}
+
+// State returns the state of a particular distro as seen in `wsl.exe -l -v`.
+// This implementation will always fail on Linux.
+func (Backend) State(distributionName string) (s state.State, err error) {
+	return s, errors.New("not implemented")
 }

--- a/internal/backend/windows/wslexe_windows.go
+++ b/internal/backend/windows/wslexe_windows.go
@@ -3,8 +3,13 @@ package windows
 // This file contains utilities to access functionality accessed via wsl.exe
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
+
+	"github.com/ubuntu/gowsl/internal/state"
 )
 
 // Shutdown shuts down all distros
@@ -44,4 +49,43 @@ func (Backend) SetAsDefault(distroName string) error {
 		return fmt.Errorf("error setting %q as default: %v, output: %s", distroName, err, out)
 	}
 	return nil
+}
+
+// State returns the state of a particular distro as seen in `wsl.exe -l -v`.
+func (Backend) State(distributionName string) (s state.State, err error) {
+	cmd := exec.Command("wsl.exe", "--list", "--all", "--verbose")
+	cmd.Env = append(cmd.Env, "WSL_UTF8=1")
+
+	out, err := cmd.Output()
+	if err != nil {
+		return s, err
+	}
+
+	/*
+		Sample output:
+		   NAME           STATE           VERSION
+		 * Ubuntu         Stopped         2
+		   Ubuntu-Preview Running         2
+	*/
+
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	var headerSkipped bool
+	for sc.Scan() {
+		if !headerSkipped {
+			headerSkipped = true
+			continue
+		}
+
+		data := strings.Fields(sc.Text())
+		if len(data) == 4 {
+			// default distro, ignoring leading asterisk
+			data = data[1:]
+		}
+
+		if data[0] == distributionName {
+			return state.NewFromString(data[1])
+		}
+	}
+
+	return state.NotRegistered, nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,46 @@
+// Package state defines the state enum so that both backends can use it
+package state
+
+import "fmt"
+
+// State is the state of a particular distro as seen in `wsl.exe -l -v`.
+type State int
+
+// The states here reported are the ones obtained via `wsl.exe -l -v`,
+// with the addition of NotRegistered.
+const (
+	Stopped State = iota
+	Running
+	Installing
+	NotRegistered
+)
+
+// NewFromString parses the name of a state as printed in `wsl.exe -l -v`
+// and returns its `State` enum value.
+func NewFromString(s string) (State, error) {
+	switch s {
+	case "Stopped":
+		return Stopped, nil
+	case "Running":
+		return Running, nil
+	case "Installing":
+		return Installing, nil
+	}
+
+	return -1, fmt.Errorf("could not parse state %q", s)
+}
+
+func (s State) String() string {
+	switch s {
+	case Stopped:
+		return "Stopped"
+	case Running:
+		return "Running"
+	case Installing:
+		return "Installing"
+	case NotRegistered:
+		return "NotRegistered"
+	}
+
+	return fmt.Sprintf("Unknown state %d", s)
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,70 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/gowsl/internal/state"
+)
+
+func TestStateFromString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input string
+
+		want    state.State
+		wantErr bool
+	}{
+		"Stopped":    {input: "Stopped", want: state.Stopped},
+		"Running":    {input: "Running", want: state.Running},
+		"Installing": {input: "Installing", want: state.Installing},
+
+		// Error cases
+		"Error with made-up state": {input: "Discombobulating", wantErr: true},
+		"Error with empty string":  {input: "", wantErr: true},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := state.NewFromString(tc.input)
+			if tc.wantErr {
+				require.Error(t, err, "Unexpected success parsing wrong input")
+				return
+			}
+			require.NoError(t, err, "NewFromString should not fail with valid inputs")
+
+			require.Equal(t, tc.want, got, "Unexpected state returned by NewFromString")
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input state.State
+		want  string
+	}{
+		"Stopped":       {input: state.Stopped, want: "Stopped"},
+		"Running":       {input: state.Running, want: "Running"},
+		"Installing":    {input: state.Installing, want: "Installing"},
+		"NotRegistered": {input: state.NotRegistered, want: "NotRegistered"},
+
+		// Error case
+		"Error with made-up state": {input: 35, want: "Unknown state 35"},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.input.String()
+			require.Equal(t, tc.want, got, "Unexpected text returned by state.String()")
+		})
+	}
+}

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -2,6 +2,8 @@ package mock
 
 import (
 	"errors"
+
+	"github.com/ubuntu/gowsl/internal/state"
 )
 
 // Shutdown mocks the behaviour of shutting down WSL.
@@ -17,4 +19,9 @@ func (Backend) Terminate(distroName string) error {
 // SetAsDefault mocks the behaviour of setting one distro as default.
 func (Backend) SetAsDefault(distroName string) error {
 	return errors.New("not implemented")
+}
+
+// State returns the state of a particular distro as seen in `wsl.exe -l -v`.
+func (Backend) State(distributionName string) (s state.State, err error) {
+	return s, errors.New("not implemented")
 }


### PR DESCRIPTION
We’ve re-implemented this function three different times in various test utils, so it makes sense to add it to the GoWSL API.

This funciton returns whether a distro is Running, Stopped, Installing or NotRegistered

WSL-437