### PR TITLE
Bugfixes in distro lifecycle management in tests

### DIFF
--- a/distro_test.go
+++ b/distro_test.go
@@ -468,17 +468,17 @@ func asyncNewTestDistro(t *testing.T, ctx context.Context, rootFs string) wsl.Di
 	d := wsl.NewDistro(ctx, uniqueDistroName(t))
 	loc := t.TempDir()
 
+	go func() {
+		defer wg.Done()
+		installDistro(t, ctx, d.Name(), loc, rootFs)
+	}()
+
 	t.Cleanup(func() {
 		wg.Wait()
 		if err := uninstallDistro(d, false); err != nil {
 			t.Logf("Cleanup: %v", err)
 		}
 	})
-
-	go func() {
-		defer wg.Done()
-		installDistro(t, ctx, d.Name(), loc, rootFs)
-	}()
 
 	return d
 }

--- a/distro_test.go
+++ b/distro_test.go
@@ -470,7 +470,7 @@ func asyncNewTestDistro(t *testing.T, ctx context.Context, rootFs string) wsl.Di
 
 	t.Cleanup(func() {
 		wg.Wait()
-		if err := uninstallDistro(d); err != nil {
+		if err := uninstallDistro(d, false); err != nil {
 			t.Logf("Cleanup: %v", err)
 		}
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,9 @@ const (
 func TestMain(m *testing.M) {
 	ctx := testContext(context.Background())
 
+	// In case a previous run was interrupted
+	cleanUpTestWslInstances(ctx)
+
 	restore, err := backUpDefaultDistro(ctx)
 	if err != nil {
 		log.Errorf("setup: %v", err)
@@ -33,6 +36,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Warnf("cleanup: Failed to shutdown WSL")
 	}
+
 	cleanUpTestWslInstances(ctx)
 
 	os.Exit(exitVal)

--- a/registration_test.go
+++ b/registration_test.go
@@ -30,7 +30,7 @@ func TestRegister(t *testing.T) {
 
 			d := wsl.NewDistro(ctx, uniqueDistroName(t)+tc.distroSuffix)
 			defer func() {
-				err := uninstallDistro(d)
+				err := uninstallDistro(d, false)
 				if err != nil {
 					t.Logf("Cleanup: %v", err)
 				}

--- a/utils_mock_test.go
+++ b/utils_mock_test.go
@@ -35,7 +35,7 @@ func installDistro(t *testing.T, ctx context.Context, distroName, location, root
 // uninstallDistro checks if a distro exists and if it does, it unregisters it.
 //
 // TODO: Implement mock.
-func uninstallDistro(distro wsl.Distro) error {
+func uninstallDistro(distro wsl.Distro, allowShutdown bool) error {
 	return errors.New("uninstallDistro not implemented for mock back-end")
 }
 

--- a/utils_mock_test.go
+++ b/utils_mock_test.go
@@ -26,7 +26,7 @@ func testContext(ctx context.Context) context.Context {
 // TODO: Implement mock.
 //
 //nolint:revive // No, I wont' put the context before the *testing.T.
-func installDistro(t *testing.T, ctx context.Context, distroName string, rootfs string) {
+func installDistro(t *testing.T, ctx context.Context, distroName, location, rootfs string) {
 	t.Helper()
 
 	require.Fail(t, "Mock not implemented")

--- a/utils_real_test.go
+++ b/utils_real_test.go
@@ -114,7 +114,7 @@ func uninstallDistro(distro wsl.Distro, allowShutdown bool) error {
 
 // testDistros finds all distros with a mangled name.
 func registeredDistros(ctx context.Context) (distros []wsl.Distro, err error) {
-	outp, err := exec.Command("powershell.exe", "-Command", "$env:WSL_UTF8=1 ; wsl.exe --list --quiet").Output()
+	outp, err := exec.Command("powershell.exe", "-Command", "$env:WSL_UTF8=1 ; wsl.exe --list --quiet --all").Output()
 	if err != nil {
 		return distros, err
 	}

--- a/utils_real_test.go
+++ b/utils_real_test.go
@@ -30,7 +30,7 @@ func testContext(ctx context.Context) context.Context {
 // TODO: Consider if we want to retry.
 //
 //nolint:revive // No, I wont' put the context before the *testing.T.//nolint:revive
-func installDistro(t *testing.T, ctx context.Context, distroName string, rootfs string) {
+func installDistro(t *testing.T, ctx context.Context, distroName, location, rootfs string) {
 	t.Helper()
 
 	// Timeout to attempt a graceful failure
@@ -51,7 +51,7 @@ func installDistro(t *testing.T, ctx context.Context, distroName string, rootfs 
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), gracefulTimeout)
 		defer cancel()
-		cmd := fmt.Sprintf("$env:WSL_UTF8=1 ; wsl.exe --import %s %s %s", distroName, t.TempDir(), rootfs)
+		cmd := fmt.Sprintf("$env:WSL_UTF8=1 ; wsl.exe --import %s %s %s", distroName, location, rootfs)
 		o, e := exec.CommandContext(ctx, "powershell.exe", "-Command", cmd).CombinedOutput() //nolint:gosec
 
 		cmdOut <- combinedOutput{output: string(o), err: e}

--- a/utils_test.go
+++ b/utils_test.go
@@ -42,7 +42,7 @@ func newTestDistro(t *testing.T, ctx context.Context, rootfs string) wsl.Distro 
 	installDistro(t, ctx, d.Name(), t.TempDir(), rootfs)
 
 	t.Cleanup(func() {
-		err := uninstallDistro(d)
+		err := uninstallDistro(d, false)
 		if err != nil {
 			t.Logf("Cleanup: %v\n", err)
 		}
@@ -68,7 +68,7 @@ func cleanUpTestWslInstances(ctx context.Context) {
 	}
 
 	for _, d := range testInstances {
-		err := uninstallDistro(d)
+		err := uninstallDistro(d, true)
 		if err != nil {
 			log.Warnf("Cleanup: %v\n", err)
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -39,7 +39,7 @@ func newTestDistro(t *testing.T, ctx context.Context, rootfs string) wsl.Distro 
 	d := wsl.NewDistro(ctx, uniqueDistroName(t))
 	t.Logf("Setup: Registering %q\n", d.Name())
 
-	installDistro(t, ctx, d.Name(), rootfs)
+	installDistro(t, ctx, d.Name(), t.TempDir(), rootfs)
 
 	t.Cleanup(func() {
 		err := uninstallDistro(d)


### PR DESCRIPTION
This pull request attempts to mitigate problems arising from poor cleanup after tests.

### Bug 1
Sometimes a WSL instance gets stuck in uninstalling mode, messing with various other tests and subsequent test runs. This PR tackles this problem by:

- Running a cleanup before running the tests
- Allowing the cleanup to detect distros being (un)installed. This was the intended behaviour and I never noticed that these were being ignored (you need `--all` when doing `wsl -l`, whereas with `wsl -l -v` it is implicit).
- Allowing unregisterDistro to use wsl --terminate <DISTRO> and wsl --shutdown if unregistration fails. The latter is only used in the global cleanup in TestMain, to mitigate cross-test interference.

### Bug 2
Avoid WslRegisterDistribution syscall in favour of `wsl.exe` in test `TestDistroState`, as this syscall is too flaky.