### PR TITLE
Fix issues arising from golangci-lint v1.52.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,12 +40,12 @@ jobs:
     - name: Lint with mock back-end
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: v1.52.0
         args: --config=.golangci-lint.yaml --build-tags="gowslmock"
     - name: Lint with real back-end
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: v1.52.0
         args: --config=.golangci-lint.yaml
     - name: Test with mocks
       shell: bash

--- a/.golangci-lint.yaml
+++ b/.golangci-lint.yaml
@@ -50,7 +50,10 @@ issues:
     - non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
     # revive: unexported-return for functions exported only in tests, aliasing doesn't work here as the linter always goes for the underlying model which is unexported
     - 'unexported-return: exported func InitialModel(ForTests|WithPrevConfig)? returns unexported type watchdtui.model, which can be annoying to use'
-  #fix: true # we don’t want this in CI
+    # We want named parameters even if unused, as they help better document the function
+    - unused-parameter
+    # Sometimes it is more readable it do a `if err:=a(); err != nil` tha simpy `return a()`
+    - if-return
 
 nolintlint:
   require-explanation: true

--- a/mock/internal/distrostate/distro_state_tracker.go
+++ b/mock/internal/distrostate/distro_state_tracker.go
@@ -1,6 +1,6 @@
-// Package distroState implements the mocking of the state of the distro
+// Package distrostate implements the mocking of the state of the distro
 // (i.e. running, stopped, etc.).
-package distroState
+package distrostate
 
 import (
 	"errors"

--- a/mock/registry.go
+++ b/mock/registry.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ubuntu/decorate"
 	"github.com/ubuntu/gowsl/internal/backend"
-	"github.com/ubuntu/gowsl/mock/internal/distroState"
+	"github.com/ubuntu/gowsl/mock/internal/distrostate"
 )
 
 // RegistryKey wraps around a Windows registry key.
@@ -20,7 +20,7 @@ type RegistryKey struct {
 	children map[string]*RegistryKey
 	data     map[string]any
 
-	state *distroState.DistroState
+	state *distrostate.DistroState
 
 	mu sync.RWMutex
 }

--- a/mock/win32.go
+++ b/mock/win32.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ubuntu/decorate"
 	"github.com/ubuntu/gowsl/internal/flags"
-	"github.com/ubuntu/gowsl/mock/internal/distroState"
+	"github.com/ubuntu/gowsl/mock/internal/distrostate"
 )
 
 // When something fails Windows-side, it returns (1<<32 - 1).
@@ -222,7 +222,7 @@ func (b *Backend) WslRegisterDistribution(distributionName string, tarGzFilename
 			"Version":          uint8(2),
 			"DefaultUid":       uint32(0),
 		},
-		state: distroState.New(),
+		state: distrostate.New(),
 	}
 
 	// When registering the first distro, DefaultDistribution


### PR DESCRIPTION
This is currently blocking other PR from passing their tests such as #38 and #48.