### PR TITLE
Miscelaneous bugfixes

### DIFF
--- a/mock/win32.go
+++ b/mock/win32.go
@@ -32,7 +32,10 @@ func (b *Backend) WslConfigureDistribution(distributionName string, defaultUID u
 		return err
 	}
 
+	b.lxssRootKey.mu.RLock()
 	_, key := b.findDistroKey(distributionName)
+	b.lxssRootKey.mu.RUnlock()
+
 	if key == nil {
 		return errors.New("failed syscall: distro not registered")
 	}

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -76,7 +76,10 @@ func (backend Backend) State(distributionName string) (s state.State, err error)
 		return state.Error, Error{}
 	}
 
+	backend.lxssRootKey.mu.RLock()
 	_, key := backend.findDistroKey(distributionName)
+	backend.lxssRootKey.mu.RUnlock()
+
 	if key == nil {
 		return state.NotRegistered, nil
 	}

--- a/registration.go
+++ b/registration.go
@@ -60,6 +60,9 @@ func registeredDistros(backend backend.Backend) (distros map[string]uuid.UUID, e
 	defer r.Close()
 
 	subkeys, err := r.SubkeyNames()
+	if err != nil {
+		return distros, err
+	}
 
 	distros = make(map[string]uuid.UUID, len(subkeys))
 	for _, key := range subkeys {


### PR DESCRIPTION
- [9964da8](https://github.com/ubuntu/GoWSL/pull/60/commits/9964da853a3007474c6d46fc0d6f42398479ec9a): Solves a missing error check in the middle-end.
- [23fcdb8](https://github.com/ubuntu/GoWSL/pull/60/commits/23fcdb82a78f9496919ea5b2a3c4bf859fcdf8d3): Solves a potential data race in the mock.
- [24003a6](https://github.com/ubuntu/GoWSL/pull/60/commits/24003a65eb2921a07cfc0c87b2b47eb783bd99fb): Solves another potential data race in the mock.