### PR TITLE
Increase test timeout

### DIFF
--- a/.github/workflows/qa-azure.yaml
+++ b/.github/workflows/qa-azure.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Test
         shell: powershell
         run: |
-          go test -shuffle=on
+          go test -shuffle=on -timeout 20m
           if ( ! $? ) { Exit(1) }
 
   stop-vm:


### PR DESCRIPTION
Lately most test runs are failing after 10m0s. However, looking at the tests that fail, they have not been running for that long (~1m) which I believe means that they are the "unlucky" test to be interrupted by the ten minute timeout.

UDENG-288