### PR TITLE
Fix mock's distrostate's deadlock

### DIFF
--- a/mock/internal/distrostate/distro_state_tracker.go
+++ b/mock/internal/distrostate/distro_state_tracker.go
@@ -214,8 +214,6 @@ func (t *DistroState) cancelTimer() {
 	if t.terminateTimer == nil {
 		return
 	}
-	if !t.terminateTimer.Stop() {
-		<-t.terminateTimer.C
-	}
+	t.terminateTimer.Stop()
 	t.terminateTimer = nil
 }


### PR DESCRIPTION
Draining an afterfunc timer leads to deadlocks in certain situations.