### PR TITLE
fix: Compare distro names with Unicode case-folding when checking if a distro is registered.

### DIFF
--- a/registration.go
+++ b/registration.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/ubuntu/decorate"
@@ -107,8 +108,13 @@ func (d Distro) isRegistered() (registered bool, err error) {
 		return false, err
 	}
 
-	_, found := distros[d.Name()]
-	return found, nil
+	for name := range distros {
+		if strings.EqualFold(name, d.Name()) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // Unregister is a wrapper around Win32's WslUnregisterDistribution.


### PR DESCRIPTION
WSL API is case-insensitive, but GoWSL was, thus failing to check whether a distro is registered if casing didn't match.
This PR leverages Unicode case-folding (a more general approach to case-insensitiveness) to compare the distro name against the ones registered.

Fixes #89 