### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -36,12 +36,12 @@ jobs:
     - name: Lint with mock back-end
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.0
+        version: v1.55.2
         args:  --build-tags="gowslmock"
     - name: Lint with real back-end
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.0
+        version: v1.55.2
     - name: Test with mocks
       shell: bash
       run: go test -tags="gowslmock" -shuffle=on


### PR DESCRIPTION
Old version of golangci-lint was causing other QA runs to fail