### PR TITLE
feat: Add return parameter to DefaultDistro indicating if there isn't a default distro

### DIFF
--- a/distro.go
+++ b/distro.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/google/uuid"
 	"github.com/ubuntu/decorate"
@@ -114,6 +115,9 @@ func DefaultDistro(ctx context.Context) (d Distro, ok bool, err error) {
 	defer r.Close()
 
 	guid, err := r.Field("DefaultDistribution")
+	if errors.Is(err, fs.ErrNotExist) {
+		return d, false, nil
+	}
 	if err != nil {
 		return d, false, err
 	}

--- a/distro.go
+++ b/distro.go
@@ -102,40 +102,44 @@ func (d *Distro) SetAsDefault() error {
 }
 
 // DefaultDistro gets the current default distribution.
-func DefaultDistro(ctx context.Context) (d Distro, err error) {
+func DefaultDistro(ctx context.Context) (d Distro, ok bool, err error) {
 	defer decorate.OnError(&err, "could not obtain the default distro")
 	backend := selectBackend(ctx)
 
 	// First, we find out the GUID of the default distro
 	r, err := backend.OpenLxssRegistry(".")
 	if err != nil {
-		return d, err
+		return d, false, err
 	}
 	defer r.Close()
 
 	guid, err := r.Field("DefaultDistribution")
 	if err != nil {
-		return d, err
+		return d, false, err
+	}
+
+	if guid == "" {
+		return d, false, nil
 	}
 
 	// Safety check: we ensure the gui is valid
 	if _, err = uuid.Parse(guid); err != nil {
-		return d, fmt.Errorf("registry returned invalid GUID: %s", guid)
+		return d, false, fmt.Errorf("registry returned invalid GUID: %s", guid)
 	}
 
 	// Last, we find out the name of the distro
 	r, err = backend.OpenLxssRegistry(guid)
 	if err != nil {
-		return d, err
+		return d, false, err
 	}
 	defer r.Close()
 
 	name, err := r.Field("DistributionName")
 	if err != nil {
-		return d, err
+		return d, false, err
 	}
 
-	return NewDistro(ctx, name), err
+	return NewDistro(ctx, name), true, err
 }
 
 // Configuration is the configuration of the distro.

--- a/distro_test.go
+++ b/distro_test.go
@@ -125,6 +125,7 @@ func TestDefaultDistro(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			ctx, modifyMock := setupBackend(t, context.Background())
 

--- a/utils_mock_test.go
+++ b/utils_mock_test.go
@@ -46,12 +46,9 @@ func registeredDistros(ctx context.Context) ([]wsl.Distro, error) {
 }
 
 // defaultDistro gets the default distro's name.
-func defaultDistro(ctx context.Context) (string, error) {
-	d, err := wsl.DefaultDistro(ctx)
-	if err != nil {
-		return "", nil
-	}
-	return d.Name(), nil
+func defaultDistro(ctx context.Context) (string, bool, error) {
+	d, ok, err := wsl.DefaultDistro(ctx)
+	return d.Name(), ok, err
 }
 
 // setDefaultDistro sets the default distro.

--- a/utils_test.go
+++ b/utils_test.go
@@ -79,11 +79,11 @@ func cleanUpTestWslInstances(ctx context.Context) {
 // backUpDefaultDistro returns a function to restore the default distro so the machine is restored to
 // its pre-testing state.
 func backUpDefaultDistro(ctx context.Context) (func(), error) {
-	distroName, err := defaultDistro(ctx)
+	distroName, ok, err := defaultDistro(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to back up default distro: %v", err)
 	}
-	if len(distroName) == 0 {
+	if !ok {
 		return func() {}, nil // No distros registered: no backup needed
 	}
 	restore := func() {


### PR DESCRIPTION
Up until now we returned an error similar to "couldn't parse uuid". This is bad because having no default distros is not a failure mode; it just means that you have no distros installed.

---

Supports UDENG-2423