### PR TITLE
fix(tests): Relax timeout in TestShell

### DIFF
--- a/shell_test.go
+++ b/shell_test.go
@@ -84,7 +84,7 @@ func TestShell(t *testing.T) {
 
 			// Because Shell is an interactive command, it needs to be quit from
 			// outside. This goroutine sets a fuse before shutting down the distro.
-			tk := time.AfterFunc(3*time.Second, func() {
+			tk := time.AfterFunc(10*time.Second, func() {
 				t.Logf("Command timed out")
 				err := d.Terminate()
 				if err != nil {


### PR DESCRIPTION
This test was failing quite often (e.g. https://github.com/ubuntu/GoWSL/actions/runs/8139480614/job/22386067331?pr=101)

We can relax the timeout a bit.