### PR TITLE
feat: Return ErrNotExist when a distro does not exist

### DIFF
--- a/backend_mock.go
+++ b/backend_mock.go
@@ -43,3 +43,6 @@ func selectBackend(ctx context.Context) backend.Backend {
 	//nolint:forcetypeassert // The panic is expected and welcome
 	return v.(backend.Backend)
 }
+
+// ErrNotExist is the error returned when a distro does not exist.
+var ErrNotExist = mock.ErrNotExist

--- a/backend_real.go
+++ b/backend_real.go
@@ -32,3 +32,6 @@ func WithMock(ctx context.Context, m *mock.Backend) context.Context {
 func selectBackend(ctx context.Context) backend.Backend {
 	return windows.Backend{}
 }
+
+// ErrNotExist is the error returned when a distro does not exist.
+var ErrNotExist = windows.ErrNotExist

--- a/distro.go
+++ b/distro.go
@@ -58,7 +58,7 @@ func (d *Distro) GUID() (id uuid.UUID, err error) {
 	}
 	id, ok := distros[d.Name()]
 	if !ok {
-		return id, errors.New("distro is not registered")
+		return id, ErrNotExist
 	}
 	return id, nil
 }
@@ -211,6 +211,10 @@ func (d *Distro) DriveMountingEnabled(value bool) (err error) {
 func (d Distro) GetConfiguration() (c Configuration, err error) {
 	defer decorate.OnError(&err, "could not access configuration for %s", d.name)
 
+	if err := d.mustBeRegistered(); err != nil {
+		return c, err
+	}
+
 	var conf Configuration
 	var f flags.WslFlags
 
@@ -247,6 +251,10 @@ func (d Distro) String() string {
 //   - PathAppended
 //   - DriveMountingEnabled
 func (d *Distro) configure(config Configuration) error {
+	if err := d.mustBeRegistered(); err != nil {
+		return err
+	}
+
 	flags, err := config.Pack()
 	if err != nil {
 		return err

--- a/distro_test.go
+++ b/distro_test.go
@@ -302,7 +302,7 @@ func TestGUID(t *testing.T) {
 	}{
 		"Success with a real distro": {distro: &realDistro},
 
-		"Error with a non-registered  distro": {distro: &fakeDistro, wantErr: true, wantNotExistErr: true},
+		"Error with a non-registered distro": {distro: &fakeDistro, wantErr: true, wantNotExistErr: true},
 		"Error with an invalid distro name":   {distro: &wrongDistro, wantErr: true},
 
 		// Mock-induced errors

--- a/distro_test.go
+++ b/distro_test.go
@@ -67,21 +67,22 @@ func TestTerminate(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		mockErr bool
+		mockErr      bool
+		dontRegister bool
 
-		wantErr bool
+		wantErr         bool
+		wantErrNotExist bool
 	}{
 		"Success": {},
 
 		// Mock-induced errors
-		"Error because wsl.exe returns an error": {mockErr: true, wantErr: true},
+		"Error because the distro is not registered": {dontRegister: true, wantErr: true, wantErrNotExist: true},
+		"Error because wsl.exe returns an error":     {mockErr: true, wantErr: true},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, modifyMock := setupBackend(t, context.Background())
-			testDistro := newTestDistro(t, ctx, rootFS)
-			controlDistro := newTestDistro(t, ctx, rootFS)
 
 			if tc.mockErr {
 				modifyMock(t, func(m *mock.Backend) {
@@ -90,12 +91,23 @@ func TestTerminate(t *testing.T) {
 				defer modifyMock(t, (*mock.Backend).ResetErrors)
 			}
 
-			wakeDistroUp(t, testDistro)
+			controlDistro := newTestDistro(t, ctx, rootFS)
+
+			var testDistro wsl.Distro
+			if tc.dontRegister {
+				testDistro = wsl.NewDistro(ctx, uniqueDistroName(t))
+			} else {
+				testDistro = newTestDistro(t, ctx, rootFS)
+				wakeDistroUp(t, testDistro)
+			}
 			wakeDistroUp(t, controlDistro)
 
 			err := testDistro.Terminate()
 			if tc.wantErr {
 				require.Error(t, err, "Terminate should have returned an error")
+				if tc.wantErrNotExist {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "Terminate error should have been ErrNotExist")
+				}
 				return
 			}
 			require.NoError(t, err, "Terminate should have returned no error")
@@ -182,11 +194,12 @@ func TestDistroSetAsDefault(t *testing.T) {
 		nonRegisteredDistro bool
 		wslexeError         bool
 
-		wantErr bool
+		wantErr         bool
+		wantErrNotExist bool
 	}{
 		"Success setting an existing distro as default": {},
 
-		"Error when setting non-existent distro as default": {nonRegisteredDistro: true, wantErr: true},
+		"Error when setting non-existent distro as default": {nonRegisteredDistro: true, wantErr: true, wantErrNotExist: true},
 
 		// Mock-induced errors
 		"Error when wsl.exe errors out": {wslexeError: true, wantErr: true},
@@ -212,6 +225,9 @@ func TestDistroSetAsDefault(t *testing.T) {
 			err := d.SetAsDefault()
 			if tc.wantErr {
 				require.Errorf(t, err, "Unexpected success setting non-existent distro %q as default", d.Name())
+				if tc.wantErrNotExist {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "SetAsDefault should have returned ErrNotExist")
+				}
 				return
 			}
 			require.NoErrorf(t, err, "Unexpected error setting %q as default", d.Name())
@@ -281,11 +297,12 @@ func TestGUID(t *testing.T) {
 		distro               *wsl.Distro
 		registryInaccessible bool
 
-		wantErr bool
+		wantErr         bool
+		wantNotExistErr bool
 	}{
 		"Success with a real distro": {distro: &realDistro},
 
-		"Error with a non-registered  distro": {distro: &fakeDistro, wantErr: true},
+		"Error with a non-registered  distro": {distro: &fakeDistro, wantErr: true, wantNotExistErr: true},
 		"Error with an invalid distro name":   {distro: &wrongDistro, wantErr: true},
 
 		// Mock-induced errors
@@ -307,6 +324,9 @@ func TestGUID(t *testing.T) {
 			guid, err := tc.distro.GUID()
 			if tc.wantErr {
 				require.Error(t, err, "Unexpected success obtaining GUID of non-eligible distro")
+				if tc.wantNotExistErr {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "GUID error should have been ErrNotExist")
+				}
 				return
 			}
 			require.NoError(t, err, "could not obtain GUID")
@@ -339,30 +359,31 @@ func TestConfigurationSetters(t *testing.T) {
 		distro       distroType
 		syscallError bool
 
-		wantErr bool
+		wantErr         bool
+		wantErrNotExist bool
 	}{
 		// DefaultUID
 		"Success setting DefaultUID":                        {setting: DefaultUID},
 		"Error when setting DefaultUID: \\0 in name":        {setting: DefaultUID, distro: DistroInvalidName, wantErr: true},
-		"Error when setting DefaultUID: not registered":     {setting: DefaultUID, distro: DistroNotRegistered, wantErr: true},
+		"Error when setting DefaultUID: not registered":     {setting: DefaultUID, distro: DistroNotRegistered, wantErr: true, wantErrNotExist: true},
 		"Error when setting DefaultUID: syscall errors out": {setting: DefaultUID, syscallError: true, wantErr: true},
 
 		// InteropEnabled
 		"Success setting InteropEnabled":                        {setting: InteropEnabled},
 		"Error when setting InteropEnabled: \\0 in name":        {setting: InteropEnabled, distro: DistroInvalidName, wantErr: true},
-		"Error when setting InteropEnabled: not registered":     {setting: InteropEnabled, distro: DistroNotRegistered, wantErr: true},
+		"Error when setting InteropEnabled: not registered":     {setting: InteropEnabled, distro: DistroNotRegistered, wantErr: true, wantErrNotExist: true},
 		"Error when setting InteropEnabled: syscall errors out": {setting: InteropEnabled, syscallError: true, wantErr: true},
 
 		// PathAppended
 		"Success setting PathAppended":                        {setting: PathAppend},
 		"Error when setting PathAppended: \\0 in name":        {setting: PathAppend, distro: DistroInvalidName, wantErr: true},
-		"Error when setting PathAppended: not registered":     {setting: PathAppend, distro: DistroNotRegistered, wantErr: true},
+		"Error when setting PathAppended: not registered":     {setting: PathAppend, distro: DistroNotRegistered, wantErr: true, wantErrNotExist: true},
 		"Error when setting PathAppended: syscall errors out": {setting: PathAppend, syscallError: true, wantErr: true},
 
 		// DriveMountingEnabled
 		"Success setting DriveMountingEnabled":                        {setting: DriveMounting},
 		"Error when setting DriveMountingEnabled: \\0 in name":        {setting: DriveMounting, distro: DistroInvalidName, wantErr: true},
-		"Error when setting DriveMountingEnabled: not registered":     {setting: DriveMounting, distro: DistroNotRegistered, wantErr: true},
+		"Error when setting DriveMountingEnabled: not registered":     {setting: DriveMounting, distro: DistroNotRegistered, wantErr: true, wantErrNotExist: true},
 		"Error when setting DriveMountingEnabled: syscall errors out": {setting: DriveMounting, syscallError: true, wantErr: true},
 	}
 
@@ -439,7 +460,10 @@ func TestConfigurationSetters(t *testing.T) {
 				err = d.DriveMountingEnabled(false)
 			}
 			if tc.wantErr {
-				require.Errorf(t, err, "unexpected failure when setting config %s", details[tc.setting].name)
+				require.Errorf(t, err, "unexpected success when setting config %s", details[tc.setting].name)
+				if tc.wantErrNotExist {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "expected setter to return ErrNotExist")
+				}
 				return
 			}
 			require.NoErrorf(t, err, "unexpected success when setting config %s", details[tc.setting].name)
@@ -488,11 +512,12 @@ func TestGetConfiguration(t *testing.T) {
 		distroName   string // Note: distros with custom distro names will not be registered
 		syscallError bool
 
-		wantErr bool
+		wantErr         bool
+		wantErrNotExist bool
 	}{
 		"Success": {},
 
-		"Error with non-registered distro":  {distroName: "IAmNotRegistered", wantErr: true},
+		"Error with non-registered distro":  {distroName: "IAmNotRegistered", wantErr: true, wantErrNotExist: true},
 		"Error with null character in name": {distroName: "MyName\x00IsNotValid", wantErr: true},
 
 		// Mock-induced errors
@@ -520,6 +545,9 @@ func TestGetConfiguration(t *testing.T) {
 
 			if tc.wantErr {
 				require.Error(t, err, "unexpected success in GetConfiguration")
+				if tc.wantErrNotExist {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "expected GetConfiguration to return ErrNotExist")
+				}
 				return
 			}
 			require.NoError(t, err, "unexpected failure in GetConfiguration")

--- a/exec.go
+++ b/exec.go
@@ -80,14 +80,11 @@ func (d *Distro) Command(ctx context.Context, cmd string) *Cmd {
 func (c *Cmd) Start() (err error) {
 	defer decorate.OnError(&err, "could not start Cmd on distro %s with command %q", c.distro.name, c.command)
 
-	// Based on exec/exec.go.
-	r, err := c.distro.isRegistered()
-	if err != nil {
+	if err := c.distro.mustBeRegistered(); err != nil {
 		return err
 	}
-	if !r {
-		return errors.New("distro is not registered")
-	}
+
+	// Based on exec/exec.go.
 
 	if c.Process != nil {
 		return errors.New("already started")

--- a/internal/backend/windows/backend.go
+++ b/internal/backend/windows/backend.go
@@ -7,12 +7,16 @@ package windows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 )
 
 // Backend implements the Backend interface.
 type Backend struct{}
+
+// ErrNotExist is returned when a distro does not exist.
+var ErrNotExist = errors.New("distro does not exist")
 
 // RemoveAppxFamily uninstalls the Appx under the provided family name.
 func (Backend) RemoveAppxFamily(ctx context.Context, packageFamilyName string) error {

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -4,6 +4,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 )
 
@@ -70,6 +71,9 @@ type Error struct{}
 func (err Error) Error() string {
 	return "error triggered by mock"
 }
+
+// ErrNotExist is returned when a distro does not exist.
+var ErrNotExist = errors.New("distro does not exist")
 
 // RemoveAppxFamily mocks the removal of packages under a package family.
 func (b Backend) RemoveAppxFamily(ctx context.Context, packageFamilyName string) error {

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/ubuntu/gowsl/internal/state"
@@ -42,7 +43,7 @@ func (backend *Backend) Terminate(distroName string) error {
 
 	guid, key := backend.findDistroKey(distroName)
 	if guid == "" {
-		return errors.New("This is localized text, don't assert on it.\nError code: Wsl/Service/WSL_E_DISTRO_NOT_FOUND")
+		return fmt.Errorf("could not terminate distro: %w", ErrNotExist)
 	}
 
 	return key.state.Terminate()
@@ -63,7 +64,7 @@ func (backend *Backend) SetAsDefault(distroName string) error {
 
 	GUID, key := backend.findDistroKey(distroName)
 	if key == nil {
-		return errors.New("distro not registered")
+		return fmt.Errorf("could not set default: %w", ErrNotExist)
 	}
 
 	backend.lxssRootKey.Data["DefaultDistribution"] = GUID
@@ -104,7 +105,7 @@ func (backend Backend) Install(ctx context.Context, appxName string) (err error)
 	}
 
 	if appxName == "" {
-		return errors.New(`could not install "": Wsl/InstallDistro/WSL_E_DISTRO_NOT_FOUND`)
+		return fmt.Errorf("could not install: %w", ErrNotExist)
 	}
 
 	return nil

--- a/registration.go
+++ b/registration.go
@@ -122,12 +122,8 @@ func (d Distro) isRegistered() (registered bool, err error) {
 func (d *Distro) Unregister() (err error) {
 	defer decorate.OnError(&err, "could not unregister %q", d.name)
 
-	r, err := d.isRegistered()
-	if err != nil {
+	if err := d.mustBeRegistered(); err != nil {
 		return err
-	}
-	if !r {
-		return errors.New("distro is not registered")
 	}
 
 	return d.backend.WslUnregisterDistribution(d.Name())
@@ -182,4 +178,15 @@ func fixPath(relative string) (string, error) {
 		return "", errors.New("file not found")
 	}
 	return abs, nil
+}
+
+func (d Distro) mustBeRegistered() error {
+	r, err := d.isRegistered()
+	if err != nil {
+		return err
+	}
+	if !r {
+		return ErrNotExist
+	}
+	return nil
 }

--- a/shell.go
+++ b/shell.go
@@ -80,12 +80,8 @@ func WithCommand(cmd string) ShellOption {
 func (d *Distro) Shell(args ...ShellOption) (err error) {
 	defer decorate.OnError(&err, "unsuccessful shell into distro %s", d.name)
 
-	r, err := d.isRegistered()
-	if err != nil {
+	if err := d.mustBeRegistered(); err != nil {
 		return err
-	}
-	if !r {
-		return fmt.Errorf("distro %q is not registered", d.Name())
 	}
 
 	options := shellOptions{

--- a/shell_test.go
+++ b/shell_test.go
@@ -31,12 +31,13 @@ func TestShell(t *testing.T) {
 		distro      *wsl.Distro
 		syscallErr  bool
 
-		wantError    bool
-		wantExitCode uint32
+		wantError       bool
+		wantExitCode    uint32
+		wantErrNotExist bool
 	}{
 		// Test with no arguments
 		"Success":                            {distro: &realDistro},
-		"Error with a non-registered distro": {distro: &fakeDistro, wantError: true},
+		"Error with a non-registered distro": {distro: &fakeDistro, wantError: true, wantErrNotExist: true},
 		"Error with distroname with a null character": {distro: &wrongDistro, wantError: true},
 
 		// Mock-induced errors
@@ -104,6 +105,9 @@ func TestShell(t *testing.T) {
 			var target *wsl.ShellError
 			if tc.wantExitCode == 0 {
 				notErrorAsf(t, err, &target, "unexpected ShellError, expected any other type")
+				if tc.wantErrNotExist {
+					require.ErrorIs(t, err, wsl.ErrNotExist, "unexpected error type for Shell, expected a ErrNotExist")
+				}
 				return
 			}
 

--- a/utils_real_test.go
+++ b/utils_real_test.go
@@ -161,7 +161,7 @@ func setDefaultDistro(ctx context.Context, distroName string) error {
 	defer wslExeGuard(5 * time.Second)()
 
 	// No threat of code injection, wsl.exe will only interpret this text as a distro name
-	// and throw Wsl/Service/WSL_E_DISTRO_NOT_FOUND if it does not exist.
+	// and throw ErrNotExist if it does not exist.
 	out, err := exec.Command("wsl.exe", "--set-default", distroName).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to set distro %q back as default: %v. Output: %s", distroName, err, out)


### PR DESCRIPTION
I read somewhere (I think some python style guide) that there are two patterns to access resources: 
 - _Ask for permission_: Check if the resource is available before using it.
 - _Ask for forgiveness_: Try to use the resource and emit a meaningful error if it is unavailable.


The first is inherently racy as the availability of the resource may change after asking for permission. This lead our implementation to become an _ask for permission, then ask for forgiveness_ sandwich which is needlesly verbose:
```go
// Ask for permission
if ok, err := distro.IsRegistered(); err != nil {
    return err
} else if !ok {
    return ...
}

if err := distro.DoTheThing(); err != nil {
    // Ask for forgiveness
    return err
}
```

This PR makes usage a bit safer and less redundant:
```go
err := distro.DoTheThing()
if errors.Is(err, wsl.ErrNotExist) {
    // Ask for forgiveness
    return ...
} else if err != nil {
    return err
}
```

Note that internally we do ask for permission in some places, essentially every Win32 API call. This is because the error reporting of these DLL calls is atrocious, and we cannot produce a meaningful error message from them.

---

This is not for sport. The current implementation caused a test failure due to a resource availability race:

Failure: https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/8062559006/job/22022548242?pr=606#step:8:29

Code: https://github.com/canonical/ubuntu-pro-for-wsl/blob/f31559d796e8f2421acfbf4056e86e8f06854171/windows-agent/internal/distros/distro/properties.go#L34-L46

---

Part of UDENG-2385
