### PR TITLE
feat: Implement importing a distribution with a rootfs

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -32,6 +32,7 @@ type Backend interface {
 	Terminate(distroName string) error
 	SetAsDefault(distroName string) error
 	Install(ctx context.Context, appxName string) error
+	Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error
 
 	// Win32
 	WslConfigureDistribution(distributionName string, defaultUID uint32, wslDistributionFlags flags.WslFlags) error

--- a/internal/backend/windows/wslexe_linux.go
+++ b/internal/backend/windows/wslexe_linux.go
@@ -38,3 +38,9 @@ func (Backend) State(distributionName string) (s state.State, err error) {
 func (Backend) Install(ctx context.Context, appxName string) (err error) {
 	return errors.New("not implemented")
 }
+
+// Import creates a new distro from a source root filesystem.
+// This implementation will always fail on Linux.
+func (b Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
+	return errors.New("not implemented")
+}

--- a/internal/backend/windows/wslexe_windows.go
+++ b/internal/backend/windows/wslexe_windows.go
@@ -99,6 +99,15 @@ func (b Backend) Install(ctx context.Context, appxName string) error {
 	return nil
 }
 
+func (b Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
+	_, err := wslExe(ctx, "--import", distributionName, destinationPath, sourcePath)
+	if err != nil {
+		return fmt.Errorf("could not install %s: %v", distributionName, err)
+	}
+
+	return nil
+}
+
 // wslExe is a helper function to run wsl.exe with the given arguments.
 // It returns the stdout, or an error containing both stdout and stderr.
 func wslExe(ctx context.Context, args ...string) ([]byte, error) {

--- a/internal/backend/windows/wslexe_windows.go
+++ b/internal/backend/windows/wslexe_windows.go
@@ -99,6 +99,7 @@ func (b Backend) Install(ctx context.Context, appxName string) error {
 	return nil
 }
 
+// Import creates a new distro from a source root filesystem.
 func (b Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
 	_, err := wslExe(ctx, "--import", distributionName, destinationPath, sourcePath)
 	if err != nil {

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -113,7 +113,7 @@ func (backend Backend) Install(ctx context.Context, appxName string) (err error)
 }
 
 // Import creates a new distro from a source root filesystem.
-func (b *Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
+func (backend *Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
 	out, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return fmt.Errorf("import error: %v", err)
@@ -122,7 +122,7 @@ func (b *Backend) Import(ctx context.Context, distributionName, sourcePath, dest
 		return Error{}
 	}
 
-	if err := b.WslRegisterDistribution(distributionName, sourcePath); err != nil {
+	if err := backend.WslRegisterDistribution(distributionName, sourcePath); err != nil {
 		return fmt.Errorf("import error: %v", err)
 	}
 

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/ubuntu/gowsl/internal/state"
@@ -106,6 +107,22 @@ func (backend Backend) Install(ctx context.Context, appxName string) (err error)
 
 	if appxName == "" {
 		return fmt.Errorf("could not install: %w", ErrNotExist)
+	}
+
+	return nil
+}
+
+func (b *Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
+	out, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("import error: %v", err)
+	}
+	if string(out) == "MOCK_ERROR" {
+		return Error{}
+	}
+
+	if err := b.WslRegisterDistribution(distributionName, sourcePath); err != nil {
+		return fmt.Errorf("import error: %v", err)
 	}
 
 	return nil

--- a/mock/wslexe.go
+++ b/mock/wslexe.go
@@ -112,6 +112,7 @@ func (backend Backend) Install(ctx context.Context, appxName string) (err error)
 	return nil
 }
 
+// Import creates a new distro from a source root filesystem.
 func (b *Backend) Import(ctx context.Context, distributionName, sourcePath, destinationPath string) error {
 	out, err := os.ReadFile(sourcePath)
 	if err != nil {

--- a/registration.go
+++ b/registration.go
@@ -166,6 +166,27 @@ func (d *Distro) Uninstall(ctx context.Context) (err error) {
 	return d.backend.WslUnregisterDistribution(d.Name())
 }
 
+func Import(ctx context.Context, distributionName, sourcePath, destinationPath string) (Distro, error) {
+	err := os.MkdirAll(destinationPath, 0700)
+	if err != nil {
+		return Distro{}, fmt.Errorf("could not create destination path: %v", err)
+	}
+
+	stat, err := os.Stat(sourcePath)
+	if err != nil {
+		return Distro{}, fmt.Errorf("could not stat source path: %v", err)
+	} else if stat.IsDir() {
+		return Distro{}, errors.New("source path is a directory")
+	}
+
+	err = selectBackend(ctx).Import(ctx, distributionName, sourcePath, destinationPath)
+	if err != nil {
+		return Distro{}, err
+	}
+
+	return NewDistro(ctx, distributionName), nil
+}
+
 // fixPath deals with the fact that WslRegisterDistribuion is
 // a bit picky with the path format.
 func fixPath(relative string) (string, error) {

--- a/registration.go
+++ b/registration.go
@@ -166,6 +166,7 @@ func (d *Distro) Uninstall(ctx context.Context) (err error) {
 	return d.backend.WslUnregisterDistribution(d.Name())
 }
 
+// Import creates a new distro from a source root filesystem.
 func Import(ctx context.Context, distributionName, sourcePath, destinationPath string) (Distro, error) {
 	err := os.MkdirAll(destinationPath, 0700)
 	if err != nil {

--- a/registration_test.go
+++ b/registration_test.go
@@ -524,7 +524,12 @@ func TestImport(t *testing.T) {
 			if tc.distroAlreadyExists {
 				distroName = newTestDistro(t, ctx, tarball).Name()
 			}
-			defer uninstallDistro(wsl.NewDistro(ctx, distroName), false)
+			t.Cleanup(func() {
+				err := uninstallDistro(wsl.NewDistro(ctx, distroName), false)
+				if err != nil {
+					t.Logf("Cleanup: %v", err)
+				}
+			})
 
 			cancel := wslExeGuard(time.Minute)
 			d, err := wsl.Import(ctx, distroName, tarball, dst)


### PR DESCRIPTION
This adds functions for importing a WSL distro from a rootfs, which is already supported by WSL itself.

---

UDENG-2553