### PR TITLE
fix(backend): Almost empty error when wsl.exe fails.

### DIFF
--- a/internal/backend/windows/wslexe_windows.go
+++ b/internal/backend/windows/wslexe_windows.go
@@ -144,13 +144,16 @@ func wslExe(ctx context.Context, args ...string) ([]byte, error) {
 		return stdout.Bytes(), nil
 	}
 
-	if strings.Contains(stdout.String(), "Wsl/Service/WSL_E_DISTRO_NOT_FOUND") {
+	out := stdout.String()
+	e := stderr.String()
+
+	if strings.Contains(out, "Wsl/Service/WSL_E_DISTRO_NOT_FOUND") {
 		return nil, ErrNotExist
 	}
 
-	if strings.Contains(stderr.String(), "Wsl/Service/WSL_E_DISTRO_NOT_FOUND") {
+	if strings.Contains(e, "Wsl/Service/WSL_E_DISTRO_NOT_FOUND") {
 		return nil, ErrNotExist
 	}
 
-	return nil, fmt.Errorf("%v. Stdout: %s. Stderr: %s", err, stdout.Bytes(), stderr.Bytes())
+	return nil, fmt.Errorf("%v. Stdout: %s. Stderr: %s", err, out, e)
 }


### PR DESCRIPTION
If wsl.exe doesn't exit 0, then we read the byte buffer to find "Wsl/Service/WSL_E_DISTRO_NOT_FOUND".

By doing so we're exhausting the reader, so the last line of this function essentially assembles an empty message, because there is nothing more to retrieve from the reader.

The fix is write the buffer contents into strings and use those when comparing and generating error messages.
That could be a problem for very long outputs, but wsl.exe itself always generates short messages (currently at least).