### PR TITLE
fix: Distro name case insensitive everywhere

### DIFF
--- a/distro.go
+++ b/distro.go
@@ -62,7 +62,7 @@ func (d *Distro) GUID() (id uuid.UUID, err error) {
 	if err != nil {
 		return id, err
 	}
-	id, ok := distros[d.Name()]
+	id, ok := distros[strings.ToLower(d.Name())]
 	if !ok {
 		return id, ErrNotExist
 	}

--- a/distro.go
+++ b/distro.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/ubuntu/decorate"
@@ -41,6 +42,11 @@ func NewDistro(ctx context.Context, name string) Distro {
 		backend: selectBackend(ctx),
 		name:    name,
 	}
+}
+
+// Equal compares two distros for equality independent of their name casing.
+func (d Distro) Equal(other Distro) bool {
+	return d.backend == other.backend && strings.EqualFold(d.name, other.name)
 }
 
 // Name is a getter for the DistroName as shown in "wsl.exe --list".

--- a/distro_test.go
+++ b/distro_test.go
@@ -697,7 +697,8 @@ func asyncNewTestDistro(t *testing.T, ctx context.Context, rootFs string) wsl.Di
 	go func() {
 		defer wg.Done()
 
-		defer wslExeGuard(2 * time.Minute)()
+		defer wslExeGuard(3 * time.Minute)()
+		t.Logf("Setup: installing %q asynchronously", d.Name())
 		cmd := fmt.Sprintf("$env:WSL_UTF8=1 ;  wsl --import %q %q %q", d.Name(), loc, rootFs)
 		//nolint:gosec // Code injection is not a concern in tests.
 		out, err := exec.Command("powershell.exe", "-Command", cmd).CombinedOutput()

--- a/distro_test.go
+++ b/distro_test.go
@@ -547,29 +547,34 @@ func TestGetConfiguration(t *testing.T) {
 				d = wsl.NewDistro(ctx, uniqueDistroName(t)+tc.distroName)
 			}
 
-			c, err := d.GetConfiguration()
+			// Verifies case insensitiveness of distro names
+			upper := wsl.NewDistro(ctx, strings.ToUpper(d.Name()))
+			lower := wsl.NewDistro(ctx, strings.ToUpper(d.Name()))
+			for _, distro := range []*wsl.Distro{&d, &upper, &lower} {
+				c, err := distro.GetConfiguration()
 
-			if tc.wantErr {
-				require.Error(t, err, "unexpected success in GetConfiguration")
-				if tc.wantErrNotExist {
-					require.ErrorIs(t, err, wsl.ErrNotExist, "expected GetConfiguration to return ErrNotExist")
+				if tc.wantErr {
+					require.Error(t, err, "unexpected success in GetConfiguration")
+					if tc.wantErrNotExist {
+						require.ErrorIs(t, err, wsl.ErrNotExist, "expected GetConfiguration to return ErrNotExist")
+					}
+					return
 				}
-				return
-			}
-			require.NoError(t, err, "unexpected failure in GetConfiguration")
-			assert.Equal(t, uint8(2), c.Version)
-			assert.Zero(t, c.DefaultUID)
-			assert.True(t, c.InteropEnabled)
-			assert.True(t, c.PathAppended)
-			assert.True(t, c.DriveMountingEnabled)
+				require.NoError(t, err, "unexpected failure in GetConfiguration")
+				assert.Equal(t, uint8(2), c.Version)
+				assert.Zero(t, c.DefaultUID)
+				assert.True(t, c.InteropEnabled)
+				assert.True(t, c.PathAppended)
+				assert.True(t, c.DriveMountingEnabled)
 
-			defaultEnvs := map[string]string{
-				"HOSTTYPE": "x86_64",
-				"LANG":     "en_US.UTF-8",
-				"PATH":     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games",
-				"TERM":     "xterm-256color",
+				defaultEnvs := map[string]string{
+					"HOSTTYPE": "x86_64",
+					"LANG":     "en_US.UTF-8",
+					"PATH":     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games",
+					"TERM":     "xterm-256color",
+				}
+				assert.Equal(t, c.DefaultEnvironmentVariables, defaultEnvs)
 			}
-			assert.Equal(t, c.DefaultEnvironmentVariables, defaultEnvs)
 		})
 	}
 }

--- a/distro_test.go
+++ b/distro_test.go
@@ -324,7 +324,7 @@ func TestGUID(t *testing.T) {
 
 			// Verifies case insensitiveness of distro names
 			upper := wsl.NewDistro(ctx, strings.ToUpper(tc.distro.Name()))
-			lower := wsl.NewDistro(ctx, strings.ToUpper(tc.distro.Name()))
+			lower := wsl.NewDistro(ctx, strings.ToLower(tc.distro.Name()))
 			for _, d := range []*wsl.Distro{tc.distro, &upper, &lower} {
 				guid, err := d.GUID()
 				if tc.wantErr {
@@ -549,7 +549,7 @@ func TestGetConfiguration(t *testing.T) {
 
 			// Verifies case insensitiveness of distro names
 			upper := wsl.NewDistro(ctx, strings.ToUpper(d.Name()))
-			lower := wsl.NewDistro(ctx, strings.ToUpper(d.Name()))
+			lower := wsl.NewDistro(ctx, strings.ToLower(d.Name()))
 			for _, distro := range []*wsl.Distro{&d, &upper, &lower} {
 				c, err := distro.GetConfiguration()
 

--- a/distro_test.go
+++ b/distro_test.go
@@ -655,6 +655,28 @@ func TestDistroState(t *testing.T) {
 	}
 }
 
+func TestEqual(t *testing.T) {
+	ctx, _ := setupBackend(t, context.Background())
+
+	d := newTestDistro(t, ctx, rootFS)
+	upper := wsl.NewDistro(ctx, strings.ToUpper(d.Name()))
+	lower := wsl.NewDistro(ctx, strings.ToLower(d.Name()))
+
+	require.True(t, d.Equal(d), "Distro should be equal to itself")
+	require.True(t, d.Equal(upper), "Distro should be equal to itself despite the name casing")
+	require.True(t, d.Equal(lower), "Distro should be equal to itself despite the name casing")
+
+	unrelated := wsl.NewDistro(ctx, uniqueDistroName(t))
+	upper = wsl.NewDistro(ctx, strings.ToUpper(unrelated.Name()))
+	lower = wsl.NewDistro(ctx, strings.ToLower(unrelated.Name()))
+
+	require.False(t, d.Equal(unrelated), "Distro should be equal to another distro")
+	require.False(t, d.Equal(upper), "Distro should not be equal to another distro despite the name casing")
+	require.False(t, d.Equal(lower), "Distro should not be equal to another distro despite the name casing")
+	require.True(t, unrelated.Equal(upper), "Distro should be equal to itself despite the name casing")
+	require.True(t, unrelated.Equal(lower), "Distro should be equal to itself despite the name casing")
+}
+
 //nolint:revive // No, I wont' put the context before the *testing.T.
 func asyncNewTestDistro(t *testing.T, ctx context.Context, rootFs string) wsl.Distro {
 	t.Helper()

--- a/distro_test.go
+++ b/distro_test.go
@@ -649,7 +649,13 @@ func TestDistroState(t *testing.T) {
 				}
 				require.NoError(t, err, "distro.State should not return an error")
 
-				require.Equal(t, tc.want.String(), got.String(), "distro.State() does not match expected value")
+				if tc.want == wsl.Installing {
+					// The "Installing" state is transient, thus inherently racy. By the time this loop finished
+					// installation may already have finished as well and the distro may be either running or stopped, But certainly not NotRegistered.
+					require.NotEqualf(t, wsl.NonRegistered, got, "%s .State() should be one of Installing, Running, or Stopped", distro.Name())
+					continue
+				}
+				require.Equalf(t, tc.want.String(), got.String(), "%s .State() does not match expected value", distro.Name())
 			}
 		})
 	}

--- a/distro_test.go
+++ b/distro_test.go
@@ -638,14 +638,19 @@ func TestDistroState(t *testing.T) {
 				require.Failf(t, "Setup: unknown action enum", "Value: %d", tc.action)
 			}
 
-			got, err := tc.distro.State()
-			if tc.wantErr {
-				require.Error(t, err, "distro.State should return an error")
-				return
-			}
-			require.NoError(t, err, "distro.State should not return an error")
+			// The expected state shall be the same independent of the distro name casing.
+			upper := wsl.NewDistro(ctx, strings.ToUpper(tc.distro.Name()))
+			lower := wsl.NewDistro(ctx, strings.ToLower(tc.distro.Name()))
+			for _, distro := range []*wsl.Distro{tc.distro, &upper, &lower} {
+				got, err := distro.State()
+				if tc.wantErr {
+					require.Error(t, err, "distro.State should return an error")
+					continue
+				}
+				require.NoError(t, err, "distro.State should not return an error")
 
-			require.Equal(t, tc.want.String(), got.String(), "distro.State() does not match expected value")
+				require.Equal(t, tc.want.String(), got.String(), "distro.State() does not match expected value")
+			}
 		})
 	}
 }

--- a/internal/backend/windows/wslexe_windows.go
+++ b/internal/backend/windows/wslexe_windows.go
@@ -98,7 +98,7 @@ func (Backend) State(distributionName string) (s state.State, err error) {
 			data = data[1:]
 		}
 
-		if data[0] == distributionName {
+		if strings.EqualFold(data[0], distributionName) {
 			return state.NewFromString(data[1])
 		}
 	}

--- a/mock/win32.go
+++ b/mock/win32.go
@@ -335,7 +335,11 @@ func (b *Backend) findDistroKey(distroName string) (GUID string, key *RegistryKe
 		if !ok {
 			continue
 		}
-		if name != distroName {
+		n, ok := name.(string)
+		if !ok { // not a string? garbage?
+			continue
+		}
+		if !strings.EqualFold(n, distroName) {
 			continue
 		}
 

--- a/registration.go
+++ b/registration.go
@@ -83,8 +83,8 @@ func registeredDistros(backend backend.Backend) (distros map[string]uuid.UUID, e
 		if err != nil {
 			return nil, err
 		}
-
-		distros[name] = guid
+		// Let's normalize storing distro names as Unicode lower case, to prevent case sensitivity issues.
+		distros[strings.ToLower(name)] = guid
 	}
 
 	return distros, nil

--- a/registration_test.go
+++ b/registration_test.go
@@ -59,7 +59,7 @@ func TestRegister(t *testing.T) {
 				}
 			})
 
-			cancel := wslExeGuard(time.Minute)
+			cancel := wslExeGuard(3 * time.Minute)
 			t.Logf("Registering %q", d.Name())
 			err := d.Register(tc.rootfs)
 			cancel()
@@ -78,7 +78,7 @@ func TestRegister(t *testing.T) {
 			require.Truef(t, found, "Failed to find distro %v in list of registered distros %v.", d, list)
 
 			// Testing double registration failure
-			cancel = wslExeGuard(time.Minute)
+			cancel = wslExeGuard(3 * time.Minute)
 			t.Logf("Registering %q", d.Name())
 			err = d.Register(tc.rootfs)
 			cancel()
@@ -240,7 +240,7 @@ func TestUnregister(t *testing.T) {
 
 			t.Logf("Unregistering %q", d.Name())
 
-			cancel := wslExeGuard(time.Minute)
+			cancel := wslExeGuard(3 * time.Minute)
 			err := d.Unregister()
 			cancel()
 
@@ -541,7 +541,7 @@ func TestImport(t *testing.T) {
 				}
 			})
 
-			cancel := wslExeGuard(time.Minute)
+			cancel := wslExeGuard(3 * time.Minute)
 			d, err := wsl.Import(ctx, distroName, tarball, dst)
 			cancel()
 			if tc.wantErr {
@@ -591,7 +591,7 @@ func requireInstallFromAppxWindows(t *testing.T, ctx context.Context, appxName s
 	out, err := cmd.Output()
 	require.NoErrorf(t, err, "could not install: %v. Stdout: %s", err, out)
 
-	defer wslExeGuard(time.Minute)()
+	defer wslExeGuard(3 * time.Minute)()
 
 	//nolint:gosec // It's fine for tests
 	// Need to use powershell in order to find the launcher executable

--- a/registration_test.go
+++ b/registration_test.go
@@ -576,6 +576,11 @@ func requireInstallFromAppxWindows(t *testing.T, ctx context.Context, appxName s
 
 	d = wsl.NewDistro(ctx, distroName)
 	_ = d.Unregister()
+	// A previous unsuccessful installation may have left leftovers inside HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss\.
+	// We need to find the key (guid) whose names match appxName and delete that key.
+	if err := cleanupRegistry(t, d); err != nil {
+		t.Logf("when cleaning up potential leftovers inside the registry: %v", err)
+	}
 
 	cmd := exec.CommandContext(ctx,
 		"wsl.exe",

--- a/utils_cleanup_linux_test.go
+++ b/utils_cleanup_linux_test.go
@@ -1,0 +1,15 @@
+//go:build !gowslmock
+
+package gowsl_test
+
+import (
+	"testing"
+
+	wsl "github.com/ubuntu/gowsl"
+)
+
+func cleanupRegistry(t *testing.T, d wsl.Distro) error {
+	t.Helper()
+
+	panic("not implemented on linux")
+}

--- a/utils_cleanup_mock_test.go
+++ b/utils_cleanup_mock_test.go
@@ -1,0 +1,16 @@
+//go:build gowslmock
+
+package gowsl_test
+
+import (
+	"testing"
+
+	wsl "github.com/ubuntu/gowsl"
+)
+
+func cleanupRegistry(t *testing.T, d wsl.Distro) error {
+	t.Helper()
+	t.Logf("Cleaning potential registry leftovers for %q are not needed when testing with mocks\n", d.Name())
+
+	return nil
+}

--- a/utils_cleanup_windows_test.go
+++ b/utils_cleanup_windows_test.go
@@ -1,0 +1,51 @@
+//go:build !gowslmock
+
+package gowsl_test
+
+import (
+	"strings"
+	"testing"
+
+	wsl "github.com/ubuntu/gowsl"
+	"golang.org/x/sys/windows/registry"
+)
+
+// cleanupRegistry attempts to prevent error "0x8000000d An illegal state change was requested" that may arise when registering a distro
+// on top of a previously failed registration or unregistration that may have left some leftovers inside the registry.
+// This is an educated guess based on this comment: https://github.com/microsoft/WSL/issues/4084#issuecomment-774731220
+func cleanupRegistry(t *testing.T, d wsl.Distro) error {
+	t.Helper()
+
+	const lxssPath = `Software\Microsoft\Windows\CurrentVersion\Lxss\` // Path to the Lxss registry key. All WSL info is under this path
+
+	k, err := registry.OpenKey(registry.CURRENT_USER, lxssPath, registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+
+	subkeys, err := k.ReadSubKeyNames(0)
+	if len(subkeys) == 0 {
+		return err
+	}
+	for _, guid := range subkeys {
+		subKey, err := registry.OpenKey(k, guid, registry.ALL_ACCESS)
+		if err != nil {
+			return err
+		}
+
+		name, _, err := subKey.GetStringValue("DistributionName")
+		if err != nil {
+			return err
+		}
+
+		if !strings.EqualFold(name, d.Name()) {
+			continue
+		}
+
+		if err = registry.DeleteKey(k, guid); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/utils_real_test.go
+++ b/utils_real_test.go
@@ -31,7 +31,7 @@ import (
 func installDistro(t *testing.T, ctx context.Context, distroName, location, rootfs string) {
 	t.Helper()
 
-	defer wslExeGuard(2 * time.Minute)()
+	defer wslExeGuard(3 * time.Minute)()
 
 	cmd := fmt.Sprintf("$env:WSL_UTF8=1 ;  wsl --import %q %q %q", distroName, location, rootfs)
 


### PR DESCRIPTION
wsl.exe and the WSL API treat distro names case-insensitively. So should GoWSL. There are still a few places where we don't consider that and assume raw string comparisons, which leads us to interpret `Ubuntu-24.04` as not registered because it's writen in the registry as `ubuntu-24.04`. That was mostly invisble until the new image format became the default. We declared the distro name as lowecase inside `/etc/wsl-distribution.conf` and that revealed some bugs in client code of GoWSL affected by raw string comparison of distro names.

This PR should address once and for all this issue with case sensitiveness (at least as long as upstream WSL does not flip the switch and start considering instance names case-sensitively, which is not a standard behaviour on Windows anyway).

The last three commits address issues that I only found in the Azure VM CI. I couldn't reproduce them on my laptop and apparently they are not an issue on GH hosted runners, but they are conceptual issues that I believe are worth addressing, now that I figured out what seems to cause them.

There was a last failure that I gave up on troubleshooting: failed to run `wsl --shutdown`. That's probably a crash in `wslservice.exe` which would require elevated permissions to restart, too complicated to solve for a CI workflow. That's the main motivation for investing in #134 .

--- 

UDENG-6002